### PR TITLE
:recycle: Refactorización de la llamada al método en CargoProcesoService

### DIFF
--- a/app/Services/CargoProcesoService.php
+++ b/app/Services/CargoProcesoService.php
@@ -358,16 +358,12 @@ class CargoProcesoService
 
         $sumaTps = null;
         foreach ($notasTps as $tp) {
-            if (is_numeric($this->calificacionService->calificacionParcialByProceso($proceso->id, $tp->id))) {
-                $sumaTps += $this->calificacionService->calificacionParcialByProceso($proceso->id, $tp->id);
+            if (is_numeric($this->calificacionService->calificacionTpByProceso($proceso->id, $tp->id))) {
+                $sumaTps += $this->calificacionService->calificacionTpByProceso($proceso->id, $tp->id);
             }
         }
 
-
-//        $sumaTps = array_sum($notasTps->pluck('nota')->toArray());
-
         $sumaPs = null;
-
         foreach ($parciales as $ps) {
             if (is_numeric($this->calificacionService->calificacionParcialByProceso($proceso->id, $ps->id))) {
                 $sumaPs += $this->calificacionService->calificacionParcialByProceso($proceso->id, $ps->id);


### PR DESCRIPTION
La llamada al método dentro de CargoProcesoService se ha actualizado de 'calificacionParcialByProceso' a 'calificacionTpByProceso' para una mejor funcionalidad general de la clase. Este cambio se implementó para facilitar el cálculo correcto y la suma de 'notasTps'. También se eliminaron los comentarios y espacios de línea innecesarios para una mejor organización del código.