### PR TITLE
Se agrega ruta y vista para filtrar libros digitales por carrera.

### DIFF
--- a/app/Repository/Carrera/CarreraRepository.php
+++ b/app/Repository/Carrera/CarreraRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository\Carrera;
+
+use App\Models\Carrera;
+use App\Models\Resoluciones;
+
+class CarreraRepository
+{
+    public function getResolucionesBySede($sede_id)
+    {
+        $carreras = Carrera::where('sede_id', $sede_id)->get()->pluck('resolucion_id')->toArray();
+
+        return Resoluciones::whereIn('id', $carreras)->select('id', 'name')->get();
+
+    }
+
+}

--- a/app/Repository/LibroDigital/LibroDigitalRepository.php
+++ b/app/Repository/LibroDigital/LibroDigitalRepository.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Repository\LibroDigital;
+
+use App\Models\Carrera;
+use App\Models\LibroDigital;
+use App\Models\Resoluciones;
+
+class LibroDigitalRepository
+{
+    public function getLibrosBySedeResolution($sede_id, $resolution_id)
+    {
+
+        return LibroDigital::where('sede_id', $sede_id)
+            ->where('resoluciones_id', $resolution_id)
+            ->orderBy('resoluciones_id')
+            ->orderBy('number')
+            ->paginate(25)
+            ;
+
+    }
+
+}

--- a/resources/views/components/style_libro_digital.blade.php
+++ b/resources/views/components/style_libro_digital.blade.php
@@ -75,4 +75,19 @@
         opacity: 1;
     }
 
+    .pagination-responsive {
+        flex-wrap: wrap;
+        justify-content: center;
+    }
+
+    .pagination-responsive li {
+        margin-bottom: 10px;
+    }
+
+    @media (min-width: 768px) {
+        .pagination-responsive li {
+            margin-bottom: 0;
+        }
+    }
+
 </style>

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -31,7 +31,6 @@
                         Avisos
                     </a>
                 @endif
-
                 @if(Session::has('actividad'))
                     <a class="nav-link" href="{{ route('registros.index') }}">
                         <div class="sb-nav-link-icon"><i class="fas fa-paste"></i></div>
@@ -147,8 +146,14 @@
                         Mesas de Exámenes
                     </a>
                 @endif
-
-
+                @if(Session::has('admin')|| Session::has('regente')
+                    || Session::has('mesas')||Session::has('admin_alumnos')||Session::has('coordinador'))
+                        <div class="sb-sidenav-menu-heading">Lbros</div>
+                        <a class="nav-link" href="{{ route('libros_digitales.libro_digital.index_sede') }}">
+                            <div class="sb-nav-link-icon"><i class="fa-solid fa-book-bookmark"></i></div>
+                            Libro de Actas de Exámenes
+                        </a>
+                    @endif
                 @if(Session::has('alumno'))
                     <div class="sb-sidenav-menu-heading">Alumno</div>
                     <a class="nav-link" href="{{ route('alumno.detalle',Auth::user()->alumno()) }}">
@@ -172,6 +177,8 @@
                     {{--                    </a>--}}
                     {{--                     ----->--}}
                 @endif
+
+
                 <a class="nav-link" href="{{ route('libraries.library.index') }}">
                     <div class="sb-nav-link-icon"><i class="fas fa-book"></i></div>
                     Biblioteca

--- a/resources/views/libros_digitales/index_carrera.blade.php
+++ b/resources/views/libros_digitales/index_carrera.blade.php
@@ -1,0 +1,116 @@
+@extends('layouts.app-prueba')
+
+@section('content')
+    <x-style_libro_digital/>
+
+    @if(Session::has('success_message'))
+        <div class="alert alert-success alert-dismissible" role="alert">
+            {!! session('success_message') !!}
+
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    @endif
+    @if(Session::has('alert_message'))
+        <div class="alert alert-danger alert-dismissible" role="alert">
+            {!! session('alert_message') !!}
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    @endif
+
+    <div class="card text-bg-theme">
+
+        <div class="card-header d-flex justify-content-between align-items-center p-3">
+            <h4 class="m-0">Libros Digitales</h4>
+        </div>
+        <div class="d-flex justify-content-center align-items-center p-3">
+            <nav aria-label="navegación text-center">
+                <div class="dropdown">
+                    <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-expanded="false">
+                        Seleccionar resolución
+                    </button>
+                    <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                        @foreach($resolutions as $resolution)
+                            <li><a class="dropdown-item
+                             @if($resolution->id == $resolution_id) active @endif
+                             " href="{{ route('libros_digitales.libro_digital.index_carrera', ['sede' => $sede, 'resolution' => $resolution->id ]) }}">{{ $resolution->name }}</a></li>
+                        @endforeach
+                    </ul>
+                </div>
+            </nav>
+        </div>
+
+        @if(count($librosDigitales) === 0)
+            <div class="card-body text-center">
+                <h4>No se encontraron libros digitales.</h4>
+            </div>
+        @else
+            <div class="col-sm-12">
+                @php
+                    $anteriorResolucion = '';
+                    $anteriorSede = '';
+                @endphp
+
+                @foreach($librosDigitales as $libroDigital)
+                    @if($anteriorSede !== $libroDigital->sede->id)
+
+                        <div class="col-sm-12">
+                            <div class="card-header d-flex justify-content-between align-items-center mx-0 my-2">
+                                {{--                                <div class="col-sm-12">--}}
+                                <h4 class="card-title">Sede: {{$libroDigital->sede->nombre}}</h4>
+                                {{--                                </div>--}}
+                            </div>
+                        </div>
+                        <div class="row">
+                            @endif
+                            @if($anteriorResolucion !== $libroDigital->resoluciones->id)
+                                <div
+                                    class="card-header bg-info text-dark d-flex justify-content-between align-items-center p-3 mt-3 my-2">
+                                    <div class="col-sm-12 mx-1 px-5">
+                                        <h4 class="card-title">
+                                            Carrera: {{$libroDigital->resoluciones->name}}</h4>
+                                        <h6 class="card-subtitle">
+                                            Resolución N°: {{$libroDigital->resoluciones->resolution}}
+                                        </h6>
+                                    </div>
+                                </div>
+
+                            @endif
+
+                            <div class="card col-sm-4 mx-auto border-2 border-primary border-left-0 shadow">
+                                <div class="card-body d-flex">
+                                    <div class="flex-grow-1 d-flex align-items-center justify-content-center"
+                                         style="width: 30%;">
+                                        <i class="fa fa-book fa-3x text-primary"></i>
+                                    </div>
+
+                                    <div style="width: 70%;">
+                                        <h5 class="card-title">Libro {{$libroDigital->romanos}}
+                                        </h5>
+                                        <p class="card-text">
+
+                                            <a href="{{ route('libros_digitales.libro_digital.showFolios', ['libroDigital' => $libroDigital->id]) }}"
+                                               class="btn btn-primary">
+                                                <i class="fas fa-eye me-2"></i> Ver folios
+                                            </a>
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+                            @php
+                                $anteriorResolucion = $libroDigital->resoluciones->id;
+                            @endphp
+                            @php
+                                $anteriorSede = $libroDigital->sede->id;
+                            @endphp
+                            @endforeach
+                        </div>
+
+                    @endif
+                <hr />
+                    <div class="d-flex justify-content-center gutter mt-3" style="font-size: 0.8em">
+                        {{ $librosDigitales->withQueryString()->links() }}
+                    </div>
+
+            </div>
+@endsection
+

--- a/resources/views/libros_digitales/showFolios.blade.php
+++ b/resources/views/libros_digitales/showFolios.blade.php
@@ -9,9 +9,26 @@
             <h4 class="m-0 alert alert-info mx-auto">
                 <small> <i class="fa fa-book"></i> </small> <i>{{ $libroDigital->romanos ?? 'Libro Digital' }}</i>
                 -
-                <small><i class="fas fa-book-open"></i> </small> <i>{{$libroDigital->resoluciones->name??''}}</i>
+                <a href="{{ route('libros_digitales.libro_digital.index_carrera',
+                    ['sede' => $libroDigital->sede->id, 'resolution' => $libroDigital->resoluciones->id]) }}"
+                   class="alert alert-info" data-bs-toggle="tooltip" data-bs-placement="top"
+                   title="Clic para ver todos los libros de la sede {{$libroDigital->resoluciones->name??'Resolució́n'}}"
+                >
+                    <small><i class="fas fa-book-open"></i> </small> <i>{{$libroDigital->resoluciones->name??''}}</i>
+                </a>
+
                 -
-                <small><i class="fas fa-building"></i></small> <i>{{$libroDigital->sede->nombre??''}}</i>
+                <a href="{{ route('libros_digitales.libro_digital.index_sede', ['sede_id' => $libroDigital->sede->nombre]) }}"
+                   class="alert alert-info"
+                   data-bs-toggle="tooltip"
+                   data-bs-placement="top"
+                   title="Clic para ver todos los libros de la sede {{$libroDigital->sede->nombre??'Sede'}}"
+                >
+                    <small><i class="fas fa-building"></i></small>
+                    <i>{{$libroDigital->sede->nombre??'Sede'}}</i>
+                </a>
+
+
             </h4>
 
         </div>
@@ -45,20 +62,23 @@
 
                         <h6 class="card-text col-sm-5 ml-5">
                             Coordinador: <i
-                                class="text-primary">{{ optional($folio->coordinador)->getApellidoNombre()??'-' }} </i><br>
+                                    class="text-primary">{{ optional($folio->coordinador)->getApellidoNombre()??'-' }} </i><br>
                             Operador: <i
-                                class="text-primary">{{ optional($folio->operador)->getApellidoNombre()??'-' }}</i> <br>
+                                    class="text-primary">{{ optional($folio->operador)->getApellidoNombre()??'-' }}</i>
+                            <br>
                             Presidente: <i
-                                class="text-primary">{{ optional($folio->presidente)->getApellidoNombre() }}</i> <br>
+                                    class="text-primary">{{ optional($folio->presidente)->getApellidoNombre() }}</i>
+                            <br>
                             Vocal 1: <i
-                                class="text-primary">{{ optional($folio->vocal1)->getApellidoNombre() ??  $folio->vocal_id }} </i><br>
+                                    class="text-primary">{{ optional($folio->vocal1)->getApellidoNombre() ??  $folio->vocal_id }} </i><br>
                             Vocal 2: <i
-                                class="text-primary">{{ optional($folio->vocal2)->getApellidoNombre() ??  $folio->vocal_2_id }} </i><br>
+                                    class="text-primary">{{ optional($folio->vocal2)->getApellidoNombre() ??  $folio->vocal_2_id }} </i><br>
                         </h6>
                     </div>
                     <div class="card-footer text-left container">
                         @foreach($folio->folioNotas()->get() as $folioNota)
-                            <div class="row col-sm-12 border border-dark border-1 border-top-0 hover-effect zoom-effect">
+                            <div
+                                    class="row col-sm-12 border border-dark border-1 border-top-0 hover-effect zoom-effect">
                             <span class="col-sm-1">
                                 {{$folioNota->orden}}
                             </span>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1045,6 +1045,8 @@ Route::group(['prefix' => 'libros_digitales', 'middleware' => ['auth']], static 
         ->name('libros_digitales.libro_digital.index');
     Route::get('/libro/sede', [LibrosDigitalesController::class, 'indexSede'])
         ->name('libros_digitales.libro_digital.index_sede');
+    Route::get('/libro/carrera', [LibrosDigitalesController::class, 'indexCarrera'])
+        ->name('libros_digitales.libro_digital.index_carrera');
     Route::get('/create', [LibrosDigitalesController::class, 'create'])
         ->name('libros_digitales.libro_digital.create');
     Route::get('/show/{libroDigital}', [LibrosDigitalesController::class, 'show'])


### PR DESCRIPTION
Se implementó una nueva ruta /libro/carrera para filtrar los libros digitales basándose en la carrera y resolución. Se añadió la vista correspondiente index_carrera.blade.php y las clases de repositorio de apoyo para recuperar los datos de la carrera y del libro digital. Se modificaron las vistas y el controlador existentes para integrar esta nueva funcionalidad.