### PR TITLE
Agregamos un método para recuperar mesa inscriptos por llamado

### DIFF
--- a/app/Http/Controllers/LibrosController.php
+++ b/app/Http/Controllers/LibrosController.php
@@ -2,14 +2,19 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\ActaVolante;
 use App\Models\Libro;
-use App\Models\MasterMateria;
 use App\Models\Mesa;
+use App\Models\MesaAlumno;
 use App\Services\Trianual\LibroDigitalService;
 use Exception;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 
 class LibrosController extends Controller
@@ -25,10 +30,9 @@ class LibrosController extends Controller
         $this->libroDigitalService = $libroDigitalService;
     }
 
+
     /**
-     * Display a listing of the resource.
-     *
-     * @return \Illuminate\Http\Response
+     * @return Application|Factory|View|\Illuminate\View\View
      */
     public function index()
     {
@@ -45,7 +49,7 @@ class LibrosController extends Controller
     /**
      * Show the form for creating a new resource.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function create()
     {
@@ -55,21 +59,19 @@ class LibrosController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @param \Illuminate\Http\Request $request
-     * @return \Illuminate\Http\JsonResponse
+     * @param Request $request
+     * @return JsonResponse
      */
-    public function store(Request $request)
+    public function store(Request $request): JsonResponse
     {
         $validation = Validator::make($request->all(), [
             'mesa_id' => ['required'],
             'llamado' => ['required'],
         ]);
 
-
         if (!$validation->fails()) {
             try {
                 foreach ($request['folios'] as $folio) {
-
                     $numero_folio = explode('-', $folio);
                     $request['folio'] = $numero_folio[0];
                     $request['orden'] = $numero_folio[1];
@@ -91,13 +93,12 @@ class LibrosController extends Controller
                     }
 
                     $this->setLibroActasVolantes($libro);
+
                     if (!$libroExist) {
                         $this->libroDigitalService->cargaLibroDigitaByLibro($libro, Auth::user());
                     } else {
                         $this->libroDigitalService->actualizaLibroDigitaByLibro($libroAnterior, $libro, Auth::user(), $mesa);
                     }
-
-
                 }
                 $data = [
                     'status' => 'success',
@@ -124,9 +125,9 @@ class LibrosController extends Controller
      * Display the specified resource.
      *
      * @param int $id
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
-    public function show($id)
+    public function show(int $id)
     {
         //
     }
@@ -135,9 +136,9 @@ class LibrosController extends Controller
      * Show the form for editing the specified resource.
      *
      * @param int $id
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
-    public function edit($id)
+    public function edit(int $id)
     {
         //
     }
@@ -145,11 +146,11 @@ class LibrosController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param \Illuminate\Http\Request $request
+     * @param Request $request
      * @param int $id
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
-    public function update(Request $request, $id)
+    public function update(Request $request, int $id)
     {
         //
     }
@@ -158,26 +159,35 @@ class LibrosController extends Controller
      * Remove the specified resource from storage.
      *
      * @param int $id
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
-    public function destroy($id)
+    public function destroy(int $id)
     {
         //
     }
 
-    private function setLibroActasVolantes($libro)
+    /**
+     * @param Libro $libro
+     * @return void
+     */
+    private function setLibroActasVolantes(Libro $libro): void
     {
+        /** @var Mesa $mesa */
         $mesa = $libro->mesa;
-
-        if ($libro->llamado == 1) {
-            $inscripciones = $mesa->mesa_inscriptos_primero($libro->orden);
-        } elseif ($libro->llamado == 2) {
-            $inscripciones = $mesa->mesa_inscriptos_segundo($libro->orden);
-        } else {
-            $inscripciones = $mesa->mesa_inscriptos();
+        $llamado = false;
+        if ($libro->llamado === "2") {
+            $llamado = true;
         }
+
+        $inscripciones = $mesa->mesa_inscriptos_by_llamado($libro->orden, $llamado);
+
+        /** @var MesaAlumno $inscripcion */
         foreach ($inscripciones as $inscripcion) {
+
+            /** @var ActaVolante $acta_volante */
+
             $acta_volante = $inscripcion->acta_volante ?? null;
+
             if ($acta_volante) {
                 $acta_volante->libro_id = $libro->id;
                 $acta_volante->update();

--- a/app/Models/Libro.php
+++ b/app/Models/Libro.php
@@ -57,7 +57,7 @@ class Libro extends Model
             $llamado = $this->llamado;
 
             $segundoLlamado = false;
-            if($llamado === 2){
+            if($llamado === "2"){
                 $segundoLlamado = true;
             }
 
@@ -66,14 +66,11 @@ class Libro extends Model
                 'segundo_llamado' => $segundoLlamado
             ])->pluck('id');
 
-
-
             $actasVolantes = ActaVolante::whereIn('mesa_alumno_id', $mesaAlumno)->get()
                 ->sortBy(function ($acta, $key) {
                     return $acta->alumno->apellidos . ' ' . $acta->alumno->nombre;
                 })
             ;
-
 
             foreach ($actasVolantes as $acta) {
                 $acta->libro_id = $this->id;

--- a/app/Models/Mesa.php
+++ b/app/Models/Mesa.php
@@ -86,6 +86,20 @@ class Mesa extends Model
         return $inscriptos->orderBy('apellidos', 'ASC')->get();
     }
 
+
+    public function mesa_inscriptos_by_llamado(int $orden, bool $segundo): Collection
+    {
+        $take = 26;
+        $skip = $take * ($orden - 1);
+        $inscriptos = $this->hasMany(MesaAlumno::class)
+            ->where(['estado_baja' => false, 'segundo_llamado' => $segundo]);
+
+        $inscriptos = $inscriptos->skip($skip)
+            ->take($take);
+
+        return $inscriptos->orderBy('apellidos', 'ASC')->get();
+    }
+
     /**
      * @param int $orden
      * @param bool $all
@@ -325,8 +339,5 @@ class Mesa extends Model
     {
         return (new MesaService())->getDesgloseAprobados($this);
     }
-
-
-
 
 }

--- a/app/Services/LibroService.php
+++ b/app/Services/LibroService.php
@@ -4,7 +4,6 @@ namespace App\Services;
 
 use App\Models\ActaVolante;
 use App\Models\Libro;
-use App\Models\Mesa;
 use App\Models\Nota;
 
 class LibroService
@@ -37,40 +36,39 @@ class LibroService
             ->where('min', '60')->first();
 
 //        // Obtener todas las actas volantes para la mesa actual
-        if($inscripciones === true){
+        if ($inscripciones === true) {
             $libro->obtenerActasVolantesByMesaAlumno();
-        }else{
+        } else {
             $libro->obtenerActasVolantes();
         }
 
-        // Contar las actas volantes con promedio >= nota aprobado
-        // y agregarlo al desglose
-        $desgloseAprobados['aprobados'] = ActaVolante::where(
+//        Si hay actas volantes hago el desglose
+        if (count($libro->actasVolantes) > 0) {
 
-            'promedio', '>=', (int)$notaAprobado->valor)
-            ->where('libro_id', '=', $libro->id)
-            ->count();
+            // Contar las actas volantes con promedio >= nota aprobado
+            // y agregarlo al desglose
+            $desgloseAprobados['aprobados'] = ActaVolante::where(
 
+                'promedio', '>=', (int)$notaAprobado->valor)
+                ->where('libro_id', '=', $libro->id)
+                ->count();
 
-        // Contar las actas volantes con promedio entre 0 y la nota aprobada
-        // y agregarlo al desglose
-        $desgloseAprobados['desaprobados'] = ActaVolante::whereBetween(
-//        $desgloseAprobados['desaprobados'] = $actasVolantes->whereBetween(
-            'promedio', [0, (int)$notaAprobado->valor - 1])
-            ->where('libro_id', '=', $libro->id)
-            ->count();
+            // Contar las actas volantes con promedio entre 0 y la nota aprobada
+            // y agregarlo al desglose
+            $desgloseAprobados['desaprobados'] = ActaVolante::whereBetween(
+                'promedio', [0, (int)$notaAprobado->valor - 1])
+                ->where('libro_id', '=', $libro->id)
+                ->count();
 
+            // Contar las actas volantes con promedio = -1 (ausentes)
+            // y agregarlo al desglose
+            $desgloseAprobados['ausentes'] = ActaVolante::where(
+                'promedio', '=', -1)
+                ->where('libro_id', '=', $libro->id)
+                ->count();
 
-        // Contar las actas volantes con promedio = -1 (ausentes)
-        // y agregarlo al desglose
-        $desgloseAprobados['ausentes'] = ActaVolante::where(
-//        $desgloseAprobados['ausentes'] = $actasVolantes->where(
-            'promedio', '=', -1)
-            ->where('libro_id', '=', $libro->id)
-            ->count();
-
-
-        $desgloseAprobados['total'] = $desgloseAprobados['aprobados'] + $desgloseAprobados['desaprobados'] + $desgloseAprobados['ausentes'];
+            $desgloseAprobados['total'] = $desgloseAprobados['aprobados'] + $desgloseAprobados['desaprobados'] + $desgloseAprobados['ausentes'];
+        }
 
         return $desgloseAprobados;
     }

--- a/app/Services/Trianual/LibroDigitalService.php
+++ b/app/Services/Trianual/LibroDigitalService.php
@@ -269,16 +269,18 @@ class LibroDigitalService
             'folio' => $libroAnterior->folio,
         ])->first();
 
-        $desglose = $libro->getResultadosActasVolantes();
+        $desglose = $libro->getResultadosActasVolantes(true);
 
-        if ($mesaFolio) {
-            $this->updateMesaFolio($desglose, $mesaFolio, $mesa, $libro, $user);
-        } else {
-            $mesaFolio = $this->setMesaFolio($desglose, $libroDigital, $mesa, $libro, $user);
+        if ($desglose) {
+            if ($mesaFolio) {
+                $this->updateMesaFolio($desglose, $mesaFolio, $mesa, $libro, $user);
+            } else {
+                $mesaFolio = $this->setMesaFolio($desglose, $libroDigital, $mesa, $libro, $user);
+            }
         }
 
+        $actas = $libro->obtenerActasVolantesByMesaAlumno();
 
-        $actas = $libro->obtenerActasVolantes();
         $orden = 0;
 
         foreach ($actas as $acta) {


### PR DESCRIPTION
Se introdujo un nuevo método mesa_inscriptos_by_llamado en el modelo Mesa para recuperar inscripciones basadas en el orden de llamado. Se refactorizaron las clases relevantes del controlador y del servicio para utilizar este método, asegurando una mejor separación de preocupaciones y un código más limpio para manejar las operaciones del libro.